### PR TITLE
updated etherpad link

### DIFF
--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ enddate: 2019-07-18       # machine-readable end date for the workshop in YYYY-M
 instructor: ["Shervin Sahba", "Simon Waldman", "Jaime Schatz", "Eleanor Lutz"] # boxed, comma-separated list of instructors' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]
 helper: ["Simon Waldman", "Hyeon Jeong Kim", "Carolin Spice", "Ezgi Yucel", "Eleanor Lutz", "Shervin Sahba"]     # boxed, comma-separated list of helpers' names, like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]
 email: ["arokem@uw.edu"]    # boxed, comma-separated list of contact email addresses for the host, lead instructor, or whoever else is handling questions, like ["marlyn.wescoff@example.org", "fran.bilas@example.org", "ruth.lichterman@example.org"]
-collaborative_notes: https://pad.carpentries.org/2019-04-24-uw # optional: URL for the workshop collaborative notes, e.g. an Etherpad or Google Docs document
+collaborative_notes: https://pad.carpentries.org/2019-07-15-uw # optional: URL for the workshop collaborative notes, e.g. an Etherpad or Google Docs document
 eventbrite: "62509841619"  # optional: alphanumeric key for Eventbrite registration, e.g., "1234567890AB" (if Eventbrite is being used)
 ---
 


### PR DESCRIPTION
Changed the collaborative_notes variable in index.md from April's SWC etherpad (https://pad.carpentries.org/2019-04-24-uw) to a new one (https://pad.carpentries.org/2019-07-15-uw)